### PR TITLE
DEVOPS-2275 V1.17.4 patch similar nodegroupset

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -44,7 +44,8 @@ var BasicIgnoredLabels = map[string]bool{
 	apiv1.LabelZoneFailureDomain:          true,
 	apiv1.LabelZoneRegion:                 true,
 	"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
-	"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify instance group names. it's value is variable, defeating check of similar node groups
+	"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify "instance group" names. it's value is variable, defeating check of similar node groups
+	"alpha.eksctl.io/nodegroup-name":      true, // this is a label used by eksctl to identify "node group" names, similar in spirit to the kops label above
 }
 
 // NodeInfoComparator is a function that tells if two nodes are from NodeGroups

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -44,6 +44,7 @@ var BasicIgnoredLabels = map[string]bool{
 	apiv1.LabelZoneFailureDomain:          true,
 	apiv1.LabelZoneRegion:                 true,
 	"beta.kubernetes.io/fluentd-ds-ready": true, // this is internal label used for determining if fluentd should be installed as deamon set. Used for migration 1.8 to 1.9.
+	"kops.k8s.io/instancegroup":           true, // this is a label used by kops to identify instance group names. it's value is variable, defeating check of similar node groups
 }
 
 // NodeInfoComparator is a function that tells if two nodes are from NodeGroups


### PR DESCRIPTION
Cherry-picks the node labels needed for balance similar node groups onto the tip of the current 1.17.4 cluster-autoscaler release tag. This is needed to maintain balance similar node groups with the 1.17.4 cluster autoscaler. 

The Drone_build-1.17.4 branch will need to be merged to a branch publish the build.